### PR TITLE
Introduce legal name for AccountTransactions

### DIFF
--- a/src/server/controllers/account-transactions.js
+++ b/src/server/controllers/account-transactions.js
@@ -50,6 +50,7 @@ export const transactionsFragment = gqlV2/* GraphQL */ `
         id
         slug
         name
+        legalName
         type
         ... on Individual {
           email
@@ -59,6 +60,7 @@ export const transactionsFragment = gqlV2/* GraphQL */ `
         id
         slug
         name
+        legalName
         type
         ... on Individual {
           email
@@ -68,6 +70,7 @@ export const transactionsFragment = gqlV2/* GraphQL */ `
         id
         slug
         name
+        legalName
         type
       }
       order {
@@ -181,6 +184,18 @@ const formatAmountAsString = (amount) => {
   return `${amountAsString} ${amount.currency}`;
 };
 
+const formatAccountName = (account) => {
+  const legalName = account?.legalName;
+  const name = account?.name;
+  if (!legalName && !name) {
+    return '';
+  } else if (legalName && name && legalName !== name) {
+    return `${legalName} (${name})`;
+  } else {
+    return legalName || name;
+  }
+};
+
 const csvMapping = {
   date: (t) => moment.utc(t.createdAt).format('YYYY-MM-DD'),
   datetime: (t) => moment.utc(t.createdAt).format('YYYY-MM-DDTHH:mm:ss'),
@@ -201,15 +216,15 @@ const csvMapping = {
   netAmount: (t) => get(t, 'netAmountInHostCurrency.value', 0),
   currency: (t) => get(t, 'amountInHostCurrency.currency'),
   accountSlug: (t) => get(t, 'account.slug'),
-  accountName: (t) => get(t, 'account.name'),
+  accountName: (t) => formatAccountName(t.account),
   accountType: (t) => get(t, 'account.type'),
   accountEmail: (t) => get(t, 'account.email'),
   oppositeAccountSlug: (t) => get(t, 'oppositeAccount.slug'),
-  oppositeAccountName: (t) => get(t, 'oppositeAccount.name'),
+  oppositeAccountName: (t) => formatAccountName(t.oppositeAccount),
   oppositeAccountType: (t) => get(t, 'oppositeAccount.type'),
   oppositeAccountEmail: (t) => get(t, 'oppositeAccount.email'),
   hostSlug: (t) => get(t, 'host.slug'),
-  hostName: (t) => get(t, 'host.name'),
+  hostName: (t) => formatAccountName(t.host),
   hostType: (t) => get(t, 'host.type'),
   orderId: (t) => get(t, 'order.id'),
   orderLegacyId: (t) => get(t, 'order.legacyId'),

--- a/src/server/controllers/account-transactions.js
+++ b/src/server/controllers/account-transactions.js
@@ -269,7 +269,9 @@ const defaultFields = [
   'netAmount',
   'currency',
   'accountSlug',
+  'accountName',
   'oppositeAccountSlug',
+  'oppositeAccountName',
 ];
 
 const applyMapping = (mapping, row) => {


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/6612
Resolve https://github.com/opencollective/opencollective/issues/4710

```csv
"datetime","shortGroup","type","kind","isRefund","isRefunded","displayAmount","amount","paymentProcessorFee","netAmount","currency","accountSlug","accountName","oppositeAccountSlug","oppositeAccountName"
"2021-08-20T10:25:02","52b03850","DEBIT","CONTRIBUTION","REFUND","","-$17.77 USD",-17.77,0,-16.88,"USD","apex","APEX","betree","Benjamin Piouffle (Betree)"
"2021-08-20T10:25:02","bf9d9806","CREDIT","HOST_FEE","REFUND","","$1.00 USD",1,0,1,"USD","apex","APEX","opensourceorg","Open Source Collective 501(c)(6) (OSC)"
```