### PR TITLE
Remove default limit for Members JSON

### DIFF
--- a/src/server/controllers/members.js
+++ b/src/server/controllers/members.js
@@ -105,11 +105,6 @@ export async function list(req, res, next) {
   if (req.query.limit) vars.limit = Number(req.query.limit);
   if (req.query.offset) vars.offset = Number(req.query.offset);
 
-  // Only return max 50 at a time
-  if (req.params.format === 'json') {
-    vars.limit = Math.min(req.query.limit, 50);
-  }
-
   let result;
   try {
     result = await simpleGraphqlRequest(query, vars, { headers });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6742

Max limit will be enforced by the API; I don't see any reason to have a different approach when the format is JSON. 

`Math.min(req.query.limit, 50)` was returning `null` (since `req.query.limit` is null), thus using the API default - 100. Before https://github.com/opencollective/opencollective-api/pull/8875, the query ended up having no limit.