### PR TITLE
Use short dates in hosted collectives export

### DIFF
--- a/src/server/controllers/hosted-collectives.ts
+++ b/src/server/controllers/hosted-collectives.ts
@@ -6,7 +6,7 @@ import gqlV2 from 'graphql-tag';
 import { compact, get, pick, toNumber, trim } from 'lodash';
 import moment from 'moment';
 
-import { amountAsString } from '../lib/formatting';
+import { amountAsString, shortDate } from '../lib/formatting';
 import { graphqlRequest } from '../lib/graphql';
 import { applyMapping, parseToBooleanDefaultFalse, parseToBooleanDefaultTrue, splitEnums } from '../lib/utils';
 import { logger } from '../logger';
@@ -170,18 +170,18 @@ const csvMapping = {
   description: 'description',
   website: 'website',
   currency: 'currency',
-  approvedAt: 'approvedAt',
+  approvedAt: (account) => shortDate(account.approvedAt),
   hostFeePercent: 'hostFeePercent',
   balance: (account) => amountAsString(account.stats.balance),
   adminEmails: (account) => compact(account.admins?.nodes.map((member) => member.account?.email)).join(','),
   adminCount: (account) => account.admins?.totalCount,
-  firstContributionDate: (account) => account.firstContributionReceived?.nodes[0]?.createdAt,
-  lastContributionDate: (account) => account.lastContributionReceived?.nodes[0]?.createdAt,
+  firstContributionDate: (account) => shortDate(account.firstContributionReceived?.nodes[0]?.createdAt),
+  lastContributionDate: (account) => shortDate(account.lastContributionReceived?.nodes[0]?.createdAt),
   totalAmountOfContributions: (account) =>
     account.stats.totalAmountReceived && amountAsString(account.stats.totalAmountReceived),
   totalNumberOfContributions: (account) => account.numberOfContributions?.totalCount,
-  firstExpenseDate: (account) => account.firstExpenseReceived?.nodes[0]?.createdAt,
-  lastExpenseDate: (account) => account.lastExpenseReceived?.nodes[0]?.createdAt,
+  firstExpenseDate: (account) => shortDate(account.firstExpenseReceived?.nodes[0]?.createdAt),
+  lastExpenseDate: (account) => shortDate(account.lastExpenseReceived?.nodes[0]?.createdAt),
   numberOfExpenses: (account) => account.numberOfExpenses?.totalCount,
 };
 

--- a/src/server/controllers/hosted-collectives.ts
+++ b/src/server/controllers/hosted-collectives.ts
@@ -6,7 +6,7 @@ import gqlV2 from 'graphql-tag';
 import { compact, get, pick, toNumber, trim } from 'lodash';
 import moment from 'moment';
 
-import { amountAsString, shortDate } from '../lib/formatting';
+import { amountAsString, formatContact, shortDate } from '../lib/formatting';
 import { graphqlRequest } from '../lib/graphql';
 import { applyMapping, parseToBooleanDefaultFalse, parseToBooleanDefaultTrue, splitEnums } from '../lib/utils';
 import { logger } from '../logger';
@@ -173,7 +173,7 @@ const csvMapping = {
   approvedAt: (account) => shortDate(account.approvedAt),
   hostFeePercent: 'hostFeePercent',
   balance: (account) => amountAsString(account.stats.balance),
-  adminEmails: (account) => compact(account.admins?.nodes.map((member) => member.account?.email)).join(','),
+  adminEmails: (account) => compact(account.admins?.nodes.map((member) => formatContact(member.account))).join(', '),
   adminCount: (account) => account.admins?.totalCount,
   firstContributionDate: (account) => shortDate(account.firstContributionReceived?.nodes[0]?.createdAt),
   lastContributionDate: (account) => shortDate(account.lastContributionReceived?.nodes[0]?.createdAt),

--- a/src/server/lib/formatting.ts
+++ b/src/server/lib/formatting.ts
@@ -21,3 +21,6 @@ export const accountNameAndLegalName = (account: { name?: string; legalName?: st
 };
 
 export const shortDate = (date: string) => moment.utc(date).format('YYYY-MM-DD');
+
+export const formatContact = (contact: { name?: string; email: string }) =>
+  `${contact.name ? `${contact.name} ` : ''}<${contact.email}>`;

--- a/src/server/lib/formatting.ts
+++ b/src/server/lib/formatting.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export const amountAsString = (amount: { currency: string; value: number }) => {
   const amountAsString = new Intl.NumberFormat('en-US', { style: 'currency', currency: amount.currency }).format(
     amount.value,
@@ -17,3 +19,5 @@ export const accountNameAndLegalName = (account: { name?: string; legalName?: st
     return legalName || name;
   }
 };
+
+export const shortDate = (date: string) => moment.utc(date).format('YYYY-MM-DD');


### PR DESCRIPTION
As requested by Lauren, in this context, a precise date is not very useful and messes up with the date parsing when they really want just to sort.