### PR TITLE
Include APPLICATION_FEE in CSV export kinds

### DIFF
--- a/src/server/controllers/account-transactions.ts
+++ b/src/server/controllers/account-transactions.ts
@@ -624,6 +624,7 @@ const getTransactionImportRowFromTransaction = (transaction) => {
 
 const allKinds = [
   'ADDED_FUNDS',
+  'APPLICATION_FEE',
   'BALANCE_TRANSFER',
   'CONTRIBUTION',
   'EXPENSE',


### PR DESCRIPTION
## Problem

Host transaction CSV exports are missing the new `APPLICATION_FEE` transactions (platform tips ledger v2, opencollective/opencollective-api#11924).

When a flatten flag is set (`flattenHostFee`, `flattenPaymentProcessorFee`, `flattenTax`), which host dashboard exports always do, the controller replaces the kind filter with the hardcoded `allKinds` list:

```js
variables.kind = difference(variables.kind || allKinds, ['HOST_FEE']);
```

`APPLICATION_FEE` was missing from that list, so the export explicitly queried every kind except the new one and application-fee rows were silently dropped.

## Fix

Add `APPLICATION_FEE` to `allKinds`. The API already exposes the kind (the GraphQL enum derives from the constant) and the frontend already handles it (opencollective/opencollective-frontend#12280).