### PR TITLE
Add guard against NULL `connectedAccounts`

### DIFF
--- a/src/server/controllers/members.js
+++ b/src/server/controllers/members.js
@@ -160,7 +160,7 @@ export async function list(req, res, next) {
       if (r.member.githubHandle) {
         return `https://github.com/${r.member.githubHandle}`;
       }
-      const githubAccount = r.member.connectedAccounts.find((c) => c.service === 'github');
+      const githubAccount = (r.member.connectedAccounts || []).find((c) => c.service === 'github');
       return githubAccount ? `https://github.com/${githubAccount.username}` : null;
     },
     website: 'member.website',


### PR DESCRIPTION
Seems that we are getting lots of errors where the `connectedAccounts` is NULL as shown below and this adds a guard against it. 

```
Aug 07 08:36:19 oc-prod-rest-api app/web.1 error: uncaughtException: Cannot read properties of null (reading 'find')
Aug 07 08:36:19 oc-prod-rest-api app/web.1 TypeError: Cannot read properties of null (reading 'find')
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at github (/app/dist/server/controllers/members.js:171:56)
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at /app/dist/server/controllers/members.js:182:27
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at Array.map (<anonymous>)
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at applyMapping (/app/dist/server/controllers/members.js:179:12)
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at Array.map (<anonymous>)
Aug 07 08:36:19 oc-prod-rest-api app/web.1     at list (/app/dist/server/controllers/members.js:189:24)
```